### PR TITLE
Current version of  z7_semantilizer  can work corretly only if typo3 <= 10.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "docs": "https://github.com/zeroseven/z7_semantilizer/blob/master/README.md"
   },
   "require": {
-    "typo3/cms-core": "^9.5 || ^10.3"
+    "typo3/cms-core": "^9.5 || 10.4.0"
   },
   "suggest": {
     "typo3/cms-fluid-styled-content": "*"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,10 +11,10 @@ $EM_CONF[$_EXTKEY] = [
     'uploadfolder' => false,
     'createDirs' => '',
     'clearCacheOnLoad' => 1,
-    'version' => '1.1.1',
+    'version' => '1.1.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.4.99',
+            'typo3' => '9.5.0-10.4.0',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
7_semantilizer depend up to typo3 <= 10.4.x

From 10.4.2 we have other namespace for PageRepository
TYPO3\CMS\Frontend\Page\PageRepository => TYPO3\CMS\Core\Domain\Repository\PageRepository