### PR TITLE
Fix previewUrl for typo3 v13.4.15

### DIFF
--- a/Classes/Events/ValidationEvent.php
+++ b/Classes/Events/ValidationEvent.php
@@ -64,7 +64,7 @@ class ValidationEvent
 
     private function getPreviewUrl(): ?UriInterface
     {
-        return GeneralUtility::makeInstance(PreviewUriBuilder::class, $this->pageUid)->withLanguage($this->languageUid)->buildUri();
+        return GeneralUtility::makeInstance(PreviewUriBuilder::class, $this->pageUid)->create($this->pageUid)->withLanguage($this->languageUid)->buildUri();
     }
 
     private function skipSemantilizer(): bool

--- a/Classes/Events/ValidationEvent.php
+++ b/Classes/Events/ValidationEvent.php
@@ -64,7 +64,7 @@ class ValidationEvent
 
     private function getPreviewUrl(): ?UriInterface
     {
-        return GeneralUtility::makeInstance(PreviewUriBuilder::class, $this->pageUid)->create($this->pageUid)->withLanguage($this->languageUid)->buildUri();
+        return PreviewUriBuilder::create($this->pageUid)->withLanguage($this->languageUid)->buildUri();
     }
 
     private function skipSemantilizer(): bool


### PR DESCRIPTION
In Typo3 v13.4.15 the previewUriBuilder in the validationEvent fails to generate an uri.
Create($pageUid) has to be called prior to buildUri().
Behaviour changed with https://github.com/typo3/typo3/commit/8cb87adba10