### PR TITLE
[BUGFIX] Mark parameters as nullable

### DIFF
--- a/Classes/ViewHelpers/AbstractHeadlineViewHelper.php
+++ b/Classes/ViewHelpers/AbstractHeadlineViewHelper.php
@@ -123,7 +123,7 @@ class AbstractHeadlineViewHelper extends AbstractTagBasedViewHelper
         return $GLOBALS['USER']['z7_semantilizer']['temp']['relations'][$relationId] ?? null;
     }
 
-    protected function renderHeadline(int $type, string $relationId = null): string
+    protected function renderHeadline(int $type, ?string $relationId = null): string
     {
         // Set content or abort if empty
         if ($content = trim((string)($this->arguments['content'] ?: $this->renderChildren()))) {

--- a/Classes/ViewHelpers/Headline/AbstractRelationViewHelper.php
+++ b/Classes/ViewHelpers/Headline/AbstractRelationViewHelper.php
@@ -15,7 +15,7 @@ class AbstractRelationViewHelper extends AbstractHeadlineViewHelper
         $this->registerArgument('of', 'string', 'Relation id', true);
     }
 
-    protected function renderHeadline(int $type, string $relationId = null): string
+    protected function renderHeadline(int $type, ?string $relationId = null): string
     {
         $this->addSemantilizerData(['relatedTo' => $this->arguments['of']]);
 


### PR DESCRIPTION
Fix deprecation warnings for php 8.4:

PHP Deprecated:  Zeroseven\Semantilizer\ViewHelpers\AbstractHeadlineViewHelper::renderHeadline(): Implicitly marking parameter $relationId as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/zeroseven/z7-semantilizer/Classes/ViewHelpers/AbstractHeadlineViewHelper.php on line 126
PHP Deprecated:  Zeroseven\Semantilizer\ViewHelpers\Headline\AbstractRelationViewHelper::renderHeadline(): Implicitly marking parameter $relationId as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/zeroseven/z7-semantilizer/Classes/ViewHelpers/Headline/AbstractRelationViewHelper.php on line 18

@srosskopf  small fix, that can break if someone has overwritten/created their own viewhelpers